### PR TITLE
Copyedit: Add alt text to images in Cloud docs (tutorials)

### DIFF
--- a/docs/cluster-deployment/deploy-to-cluster-aws/configure-aws.rst
+++ b/docs/cluster-deployment/deploy-to-cluster-aws/configure-aws.rst
@@ -27,6 +27,7 @@ subscriptions tab of the Organization overview page, where you can see any and
 all subscriptions that your organization has.
 
 .. image:: ../../_assets/img/aws-subscription-overview.png
+  :alt: CrateDB Cloud Console organization overview page
 
 Under the relevant subscription, click the *Deploy cluster* button. This will
 take you to the CrateDB Cloud configuration wizard, starting with the choice
@@ -49,6 +50,7 @@ learn more about our subscription plans, see the `reference on subscription
 plans`_.
 
 .. image:: ../../_assets/img/aws-config-plans.png
+   :alt: CrateDB Cloud plans
 
 Choose the plan of your liking by clicking the relevant *Choose* button and
 proceed.
@@ -74,6 +76,7 @@ for your project (within which the cluster will be deployed), and either name
 a new project or choose an existing one if you have one.
 
 .. image:: ../../_assets/img/aws-wizard-step1.png
+   :alt: CrateDB Cloud configuration wizard step 1
 
 You may also notice a popup in the right bottom corner. This is to welcome you
 after your signup for CrateDB Cloud. In it, you will find a link to our help
@@ -93,6 +96,7 @@ access the cluster via its URL. The password must be at least 24 characters
 long.
 
 .. image:: ../../_assets/img/aws-wizard-step2.png
+   :alt: CrateDB Cloud configuration wizard step 2
 
 You can also already set the scale unit of the cluster to the level you want
 here. As you move the slider horizontally, the different capacities
@@ -123,6 +127,7 @@ cluster. Note that Crate.io always bills for usage on an hourly basis, and only
 actual usage is ever billed.
 
 .. image:: ../../_assets/img/aws-wizard-step3.png
+   :alt: CrateDB Cloud configuration wizard step 3
 
 Take a moment to review. If you are satisfied, click *Deploy*, and the cluster
 will be deployed. Eventually, you will be forwarded to the `CrateDB Cloud

--- a/docs/cluster-deployment/deploy-to-cluster-aws/signup-aws.rst
+++ b/docs/cluster-deployment/deploy-to-cluster-aws/signup-aws.rst
@@ -27,6 +27,7 @@ the top of the AWS Marketplace front page, or go directly to `the AWS offer`_.
 The top of the offer page should look as follows:
 
 .. image:: ../../_assets/img/aws-offer.png
+   :alt: AWS Marketplace CrateDB Cloud offer
 
 The offer page provides all the information about the CrateDB Cloud offer on
 AWS you might need: a product overview, brief descriptions of the subscription
@@ -38,6 +39,7 @@ When you do, you will be referred to a page with pricing details and a request
 for confirmation, like so:
 
 .. image:: ../../_assets/img/aws-subscribe-offer.png
+   :alt: CrateDB Cloud on AWS subscription
 
 After reviewing the details, click *Subscribe*.
 
@@ -45,6 +47,7 @@ A notice will pop up, confirming your subscription and referring you to the
 configuration on the CrateDB Cloud end.
 
 .. image:: ../../_assets/img/aws-subscribe-confirm.png
+   :alt: CrateDB Cloud on AWS subscription confirmation
 
 Click on the *Set Up Your Account* button to proceed.
 
@@ -60,6 +63,7 @@ the contract is a separate product for subscription purposes. You can access it
 by going to the `CrateDB Cloud Contract landing page`_.
 
 .. image:: ../../_assets/img/aws-cloud-contract.png
+   :alt: AWS Marketplace CrateDB Cloud Contract
 
 Simply subscribe to it as you would to the CrateDB Cloud subscription. A screen
 will appear where you can confirm your subscription plan and review the prices

--- a/docs/cluster-deployment/deploy-to-cluster-azure/configure-azure.rst
+++ b/docs/cluster-deployment/deploy-to-cluster-azure/configure-azure.rst
@@ -25,6 +25,7 @@ as a Service (SaaS)* page, go to *Overview*. Now click on *Configure Account*
 at the top left of the Overview page.
 
 .. image:: ../../_assets/img/configure-account.png
+   :alt: Azure SaaS configuration screen
 
 You'll now be redirected to the CrateDB Cloud Console.
 
@@ -42,13 +43,13 @@ Wizard
 Wizard step 1
 -------------
 
-In this
-step, you must first define an organization, if you have not already done so.
-(If you have, it will be pre-selected for you.) You must also select a region
-for your project (within which the cluster will be deployed), and either name
-a new project or choose an existing one if you have one.
+In this step, you must first define an organization, if you have not already
+done so. (If you have, it will be pre-selected for you.) You must also select a
+region for your project (within which the cluster will be deployed), and either
+name a new project or choose an existing one if you have one.
 
 .. image:: ../../_assets/img/wizard-step1.png
+   :alt: CrateDB Cloud configuration wizard step 1
 
 You may also notice a popup in the right bottom corner. This is to welcome you
 after your signup for CrateDB Cloud. In it, you will find a link to our help
@@ -68,6 +69,7 @@ access the cluster via its URL. The password must be at least 24 characters
 long.
 
 .. image:: ../../_assets/img/wizard-step2.png
+   :alt: CrateDB Cloud configuration wizard step 2
 
 You can also already set the scale unit of the cluster to the level you want
 here. As you move the slider horizontally, the different capacities
@@ -97,6 +99,7 @@ cluster. Note that Crate.io always bills for usage on an hourly basis, and only
 actual usage is ever billed.
 
 .. image:: ../../_assets/img/wizard-step3.png
+   :alt: CrateDB Cloud configuration wizard step 3
 
 Take a moment to review. If you are satisfied, click *Deploy*, and the cluster
 will be deployed. Eventually, you will be forwarded to the `CrateDB Cloud

--- a/docs/cluster-deployment/deploy-to-cluster-azure/signup-azure.rst
+++ b/docs/cluster-deployment/deploy-to-cluster-azure/signup-azure.rst
@@ -37,6 +37,7 @@ Azure Portal. The Azure Portal provides a dropdown menu where you can select
 the plan you have chosen previously.
 
 .. image:: ../../_assets/img/portal-offer.png
+   :alt: Azure Portal CrateDB Cloud offer
 
 Simply select your preferred plan and confirm by clicking *Set up + Subscribe*.
 Note that you can still review the plans and pricing again at this stage before
@@ -48,6 +49,7 @@ billed for the total usage. All resources in a single Azure subscription are
 billed together.
 
 .. image:: ../../_assets/img/subscribe-offer.png
+   :alt: CrateDB Cloud on Azure subscription
 
 Once everything is set, click *Subscribe* in the bottom left corner.
 

--- a/docs/sign-up.rst
+++ b/docs/sign-up.rst
@@ -48,6 +48,7 @@ Visit the `CrateDB Cloud Console`_. You should be presented with a Microsoft
 Azure *Active Directory* (AD) sign in option:
 
 .. image:: _assets/img/cloud-sign-in-azure-new.png
+   :alt: Azure sign-in screen
 
 You must have an Azure account to proceed.
 
@@ -58,22 +59,25 @@ Sign up with Username & Password (Cognito)
 ==========================================
 
 If you select the *Username & Password* sign-in method (supported by Amazon
-Cognito), you should be presented with a username and password sign in page:
+Cognito), you should be presented with a username and password sign-in page:
 
 .. image:: _assets/img/cloud-sign-in-user-pass.png
+   :alt: Cognito sign-in screen
 
-However, before you sign in, you must first sign up for an account.
+However, before you sign *in*, you must first sign *up* for an account.
 
 Select *Sign up* from the bottom of the dialogue box. You will be redirected to
 the sign-up page:
 
 .. image:: _assets/img/cloud-sign-up.png
+   :alt: Cognito sign-up screen
 
 Fill in your details, then select *Sign up*.
 
 Next, you should see this screen:
 
 .. image:: _assets/img/cloud-verification.png
+   :alt: Cognito verification screen
 
 Check your email, fill in the code, and, finally, select *Confirm Account* to
 finish the process.
@@ -84,9 +88,10 @@ finish the process.
 Sign in
 =======
 
-Once you're signed in, you should be redirected to the `Cloud Console`_:
+Once you're signed in, you should be redirected to the CrateDB Cloud Console:
 
 .. image:: _assets/img/cloud-first-loginv2.png
+   :alt: Cloud Console without subscription
 
 There's nothing here yet.
 
@@ -95,6 +100,9 @@ However, by the end of our tutorials for :ref:`deploying a cluster via Azure
 <deploy-to-cluster-aws>`, you will have created your first CrateDB cluster and
 this page will display important information such as average response times,
 queries, logs, and so on.
+
+For more information on the CrateDB Cloud Console, refer to `our Console
+documentation`_.
 
 
 .. _sign-up-next:
@@ -107,5 +115,5 @@ Now that you have an account, you can choose a cloud provider. Follow the
 first cluster.
 
 
-.. _Cloud Console: https://crate.io/docs/cloud/reference/en/latest/overview.html
+.. _our Console documentation: https://crate.io/docs/cloud/reference/en/latest/overview.html
 .. _CrateDB Cloud Console: https://console.cratedb.cloud/


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
- Adds alt text for all images in this docs section, providing greater accessibility
- Resolves [this issue](https://github.com/crate/tech-writing-domain/issues/376)

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
