### PR TITLE
Add a CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# The users listed below are global owners and will be
+# requested for review when someone opens a pull request.
+*       @matthijskrul @SStorm @kojinkai


### PR DESCRIPTION
## Summary of changes
Add a codeowners file to automatically add default reviewer to each PR. I realise that this file was removed about 4 months as the tech writing group was disbanded. However, following an internal discussion in the Ecosystem team we decided to add code owners to our repositories and the owners are added individually here as opposed to adding in a group.


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
