### PR TITLE
Update edge.rst

### DIFF
--- a/docs/edge.rst
+++ b/docs/edge.rst
@@ -33,15 +33,15 @@ end-to-end walkthrough of the process and prerequisites.
 Disclaimer
 ==========
 
-CrateDB Edge is currently in public beta. CrateDB Edge and related services are
+CrateDB Edge is currently in Pre-Release. CrateDB Edge and related services are
 provided on an "as is" basis and may change at any time. Crate.io provides no
 guarantees or warrant regarding the usability or performance of CrateDB Edge.
 The CrateDB Cloud Service Level Agreement (SLA) is expressly disclaimed for the
-use of CrateDB Edge and related services. By using CrateDB Edge, you agree to
+use of CrateDB Edge and related services until further notice. By using CrateDB Edge, you agree to
 these terms and conditions.
 
 Should you find any errors, bugs, or functionality problems while using the
-CrateDB Edge public beta, please let us know via `our contact page`_ or our
+CrateDB Edge Pre-Release, please let us know via `our contact page`_ or our
 `support email`_.
 
 

--- a/docs/edge.rst
+++ b/docs/edge.rst
@@ -37,8 +37,8 @@ CrateDB Edge is currently in Pre-Release. CrateDB Edge and related services are
 provided on an "as is" basis and may change at any time. Crate.io provides no
 guarantees or warrant regarding the usability or performance of CrateDB Edge.
 The CrateDB Cloud Service Level Agreement (SLA) is expressly disclaimed for the
-use of CrateDB Edge and related services until further notice. By using CrateDB Edge, you agree to
-these terms and conditions.
+use of CrateDB Edge and related services until further notice. By using CrateDB 
+Edge, you agree to these terms and conditions.
 
 Should you find any errors, bugs, or functionality problems while using the
 CrateDB Edge Pre-Release, please let us know via `our contact page`_ or our


### PR DESCRIPTION
Replaced "public beta" with "Pre-Release" due to an aggreement with Product Marketing

## Summary of the changes / Why this is an improvement
Pre-Release is the wording we are going to use for the next phase of Edge which is exposing the feature as is to the whole public. 

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
